### PR TITLE
tests/legacy/p_systemd tests' fixed

### DIFF
--- a/tests/legacy/p_systemd/15-systemctl_list_non-native-services.sh
+++ b/tests/legacy/p_systemd/15-systemctl_list_non-native-services.sh
@@ -10,6 +10,10 @@ fi
 [ ${centos_ver} -lt 7 ] && exit
 t_Log "Running $0 - Checking if systemctl can check if a non-native service is enabled"
 
+if ! systemctl list-unit-files --all -t service --full --no-legend "kdump.service" >/dev/null; then
+    t_Log "The kdump.service not found -> SKIP"
+    exit 0
+fi
 systemctl is-enabled kdump.service 2> /dev/null | grep -q -E 'enabled|disabled'
 
 t_CheckExitStatus $?

--- a/tests/legacy/p_systemd/20-systemctl_list-service-status.sh
+++ b/tests/legacy/p_systemd/20-systemctl_list-service-status.sh
@@ -9,6 +9,10 @@ if [ "$CONTAINERTEST" -eq "1" ]; then
     exit 0
 fi
 
+if ! systemctl list-unit-files --all -t service --full --no-legend "auditd.service" >/dev/null; then
+    t_Log "The auditd.service not found -> SKIP"
+    exit 0
+fi
 systemctl is-active auditd.service > /dev/null
 
 t_CheckExitStatus $?

--- a/tests/legacy/p_systemd/25-journalctl.sh
+++ b/tests/legacy/p_systemd/25-journalctl.sh
@@ -12,6 +12,9 @@ fi
 teststring=098f6bcd4621d373cade4e832627b4f6
 timenow=$(date +'%T')
 echo ${teststring} > /dev/kmsg
+
+# wait for 2 seconds for journalctl to populate
+sleep 2s
 journalctl --since ${timenow} | grep -q ${teststring}
 
 t_CheckExitStatus $?


### PR DESCRIPTION
- check kdump.service and auditd.service are installed before testing their availability
- add 2 seconds wait for journalctl to populate message