### PR TITLE
tests/legacy/p_firefox support for aarch64, ppc64le and s390x 

### DIFF
--- a/tests/legacy/p_firefox/10-check_default_startpage.sh
+++ b/tests/legacy/p_firefox/10-check_default_startpage.sh
@@ -5,7 +5,7 @@
 
 t_Log "Running $0 - firefox has $firefox_start_page as default page."
 
-if (t_GetArch firefox | grep -q 'x86_64')
+if (t_GetArch firefox | egrep -qe 'x86_64|aarch64|ppc64le|s390x')
   then
   path='/usr/lib64/firefox/defaults/preferences/all-redhat.js'
   else


### PR DESCRIPTION
Add into default startpage test support for aarch64, ppc64le and s390x