### PR TITLE
AlmaLinux Kitten ("minor-lack" versions) and release 10 tests enhacements

### DIFF
--- a/tests/legacy/p_fwupd/01_fwupd_secureboot_signed.sh
+++ b/tests/legacy/p_fwupd/01_fwupd_secureboot_signed.sh
@@ -7,6 +7,7 @@ arch=$(uname -m)
 
 if [[ "$centos_ver" -ge 7 && "$arch" = "x86_64" ]] ; then
   t_InstallPackage pesign fwupd
+  [ $centos_ver -eq 10 ] && t_InstallPackage fwupd-efi
   pesign --show-signature --in /usr/libexec/fwupd/efi/fwupdx64.efi.signed|egrep -q "$grub_sb_token"
   t_CheckExitStatus $?
 else

--- a/tests/legacy/p_osbuild/1-verify_osbuild.sh
+++ b/tests/legacy/p_osbuild/1-verify_osbuild.sh
@@ -2,9 +2,8 @@
 # Author: Yuriy Kohut <ykohut@almalinux.org>
 
 # OS major version and machine hardware name
-version_major=$( rpm --eval %rhel )
 crb='PowerTools'
-if [ "x${version_major}" = "x9" ]; then
+if [ "x${centos_ver}" = "x9" -o "x${centos_ver}" = "x10" ]; then
     crb='CRB'
 fi
 
@@ -18,12 +17,19 @@ composer-cli status show || t_CheckExitStatus $?
 
 if [ "x${pungi_repository}" = "xtrue" ]; then
     t_Log "Running $0 - osbuild: Change 'baseurl' for native BaseOS and AppStream repositories into pungi one"
-    os_repo_json="/usr/share/osbuild-composer/repositories/almalinux-${version_major}.${minor_ver}.json"
+    latest_result="latest_result"
+    json_file=almalinux-${release_ver}.json
+    if [ "$centos_ver" = "$release_ver" ]; then
+        # Assume Kitten
+        latest_result="latest_result_almalinux-kitten"
+        json_file=almalinux-kitten-${release_ver}.json
+    fi
+    os_repo_json="/usr/share/osbuild-composer/repositories/${json_file}"
     test -e ${os_repo_json}.bak || cp -av ${os_repo_json} ${os_repo_json}.bak
     t_InstallPackageMinimal jq
     for repo_name in BaseOS AppStream; do
         name=${repo_name,,}
-        baseurl="http://${arch}-pungi-${version_major}.almalinux.org/almalinux/${version_major}/${arch}/latest_result/compose/${repo_name}/${arch}/os/"
+        baseurl="http://${arch}-pungi-${centos_ver}.almalinux.org/almalinux/${centos_ver}/${arch}/${latest_result}/compose/${repo_name}/${arch}/os/"
         cat ${os_repo_json} | jq --arg arch "${arch}" --arg baseurl "${baseurl}" --arg name "${name}" '(.'$arch'[] | select(.name == $name) | .baseurl) |= $baseurl' > ${os_repo_json}.new || t_CheckExitStatus $?
         mv -f ${os_repo_json}.new ${os_repo_json}
     done

--- a/tests/legacy/p_shadow-utils/20-chage_tests
+++ b/tests/legacy/p_shadow-utils/20-chage_tests
@@ -11,5 +11,7 @@ chage -d 2013-01-01 testshadow
 t_CheckExitStatus $?
 
 echo "Check that last passwd change is reported correctly"
-chage -l testshadow | grep Last | grep -q "Jan 01, 2013"
+check_date="Jan 01, 2013"
+[ $centos_ver -eq 10 ] && check_date="Dec 31, 2012"
+chage -l testshadow | grep Last | grep -q "${check_date}"
 t_CheckExitStatus $?

--- a/tests/legacy/p_vendor-release/vendor-release_os-release.sh
+++ b/tests/legacy/p_vendor-release/vendor-release_os-release.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # Author: Fabian Arrotin <arrfab@centos.org>
 
-t_Log "Running $0 - /etc/os-release has correct ABRT string for $os_name $centos_ver"
+t_Log "Running $0 - /etc/os-release has correct ABRT string for $os_name $release_ver"
 
-lines_to_check="${os_name^^}_MANTISBT_PROJECT=\"$os_name-$centos_ver\" ${os_name^^}_MANTISBT_PROJECT_VERSION=\"$centos_ver.$minor_ver\""
+lines_to_check="${os_name^^}_MANTISBT_PROJECT=\"$os_name-$centos_ver\" ${os_name^^}_MANTISBT_PROJECT_VERSION=\"$release_ver\""
 
 if [ "$centos_ver" -ge 7 ];then
 	if [[ $centos_stream == "no" ]]; then

--- a/tests/legacy/r_pdf/00_install_requirements.sh
+++ b/tests/legacy/r_pdf/00_install_requirements.sh
@@ -6,6 +6,8 @@ t_Log "Running $0 -  install package enscript, ghostscript and pdftotext"
 # Workarround for post scriptlet non-fatal errors
 yum -y remove bitstream-vera* liberation*
 #
-t_InstallPackage fontconfig @fonts
+fonts_pkgs="fontconfig"
+[ $centos_ver -ne 10 ] && fonts_pkgs="${fonts_pkgs} @fonts"
+t_InstallPackage ${fonts_pkgs}
 t_InstallPackage enscript ghostscript poppler-utils
 

--- a/tests/sysstat/iostat/disk/test.sh
+++ b/tests/sysstat/iostat/disk/test.sh
@@ -8,7 +8,7 @@ rlJournalStart
   rlRun 'TmpDir=$(mktemp -d)' 0 'Creating tmp directory' # no-reboot
   rlRun "pushd $TmpDir"
   rlRun "echo 1 > /proc/sys/vm/drop_caches" 0 "Clear out the pagecache to get an accurate reading"
-  rlRun "drive=/dev/\$(lsblk -o NAME -n -i -r | head -1)" 0 "Capture a storage device name"
+  rlRun "drive=/dev/\$(lsblk -o NAME -n -i -r | grep -v -E 'sr0|cdrom' | head -1)" 0 "Capture a storage device name"
 
   # dd options
   rlRun "bs=4196"


### PR DESCRIPTION
- /tests/legacy/functions.sh
export 'release_ver' which includes release full version like "9.4" or just major version if "kitten" or empty minor
    
- /tests/legacy/p_vendor-release, /tests/legacy/p_osbuild
use 'release_ver' instead of "centos_ver.minor_ver"
    
- /tests/legacy/p_fwupd
check, for last passwd change date, set one day back
    
- /tests/legacy/p_shadow-utils
install 'fwupd-efi' package
    
- /tests/legacy/r_pdf
don't install @fonts group

- /tests/sysstat/iostat/disk
filter CDROM related devices. They must not be used to generate read traffic with running `/bin/dd if=/dev/sr0 ...`
This might happen when there is no SCSI but only NVMe disks.