### PR TITLE
/tests/legacy/p_kvdo fixes

### DIFF
--- a/tests/legacy/p_kvdo/0-install_kvdo.sh
+++ b/tests/legacy/p_kvdo/0-install_kvdo.sh
@@ -6,13 +6,13 @@ if [ "$CONTAINERTEST" -eq "1" ]; then
     exit 0
 fi
 
-if [ "$centos_ver" -ne "8" ]; then
-  t_Log "non c8 => SKIPPING"
+if [ "$centos_ver" -ne "8" -a "$centos_ver" -ne "9" ]; then
+  t_Log "non 8 or 9 => SKIPPING"
   exit 0
 fi
 
 t_Log "Running $0 - installing beakerlib"
-t_InstallPackage git make patch 
+t_InstallPackage git make patch python3-lxml
 pushd /tmp
 git clone https://github.com/beakerlib/beakerlib
 cd beakerlib

--- a/tests/legacy/p_kvdo/check_sb.sh
+++ b/tests/legacy/p_kvdo/check_sb.sh
@@ -10,9 +10,14 @@ if [[ $os_name == "centos" ]]; then
   exit 0
 fi
 
+if [ "$centos_ver" -ne "8" -a "$centos_ver" -ne "9" ]; then
+  t_Log "non 8 or 9 => SKIPPING"
+  exit 0
+fi
+
 if [[ "$arch" = "x86_64" ]] ; then
     t_InstallPackage kmod-kvdo
-    for i in $(rpm -ql kmod-kvdo | grep "*.ko"); do
+    for i in $(rpm -ql kmod-kvdo | grep -E "*.ko"); do
         modinfo $i | grep $kmod_sb_key
         t_CheckExitStatus $?
     done


### PR DESCRIPTION
- install python3-lxml package
- run tests if 8 or 9 only
- enable "Gather Relevant Info" for 8 and 9
- disable 'uds' module check if not 8
- do not run "Smoke Test" if not 8
- fix test to verify that kmod-kvdo is correctly signed