### PR TITLE
CI: use ubuntu-24.04 runner instead of ubuntu-latest

### DIFF
--- a/.github/workflows/almalinux-compose-test-arm64.yml
+++ b/.github/workflows/almalinux-compose-test-arm64.yml
@@ -30,7 +30,7 @@ jobs:
   start-runner:
     timeout-minutes: 10              # normally it only takes 1-2 minutes
     name: Setup and start self-hosted EC2 runner
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       actions: write
     steps:

--- a/.github/workflows/almalinux-compose-test-x86_64.yml
+++ b/.github/workflows/almalinux-compose-test-x86_64.yml
@@ -30,7 +30,7 @@ on:
 jobs:
   compose-test:
     name: AlmaLinux ${{ matrix.variant }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
@@ -124,19 +124,22 @@ jobs:
 
     - name: Install Vagrant
       run: |
+        # Use Vagrant packages provided by Hashicorp as ubuntu-24.04 doesn't build ones
+        wget -O - https://apt.releases.hashicorp.com/gpg | sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+        sudo apt-get -y update
         sudo apt-get -y install vagrant
-        sudo vagrant --version
         sudo vagrant plugin install vagrant-reload
         sudo vagrant plugin install vagrant-env
 
     - name: Install the Vagrant libvirt Plugin
       run: |
-        sudo cp /etc/apt/sources.list /etc/apt/sources.list."$(date +"%F")"
-        sudo sed -i -e '/^# deb-src.*universe$/s/# //g' /etc/apt/sources.list
+        sudo cp /etc/apt/sources.list.d/ubuntu.sources /etc/apt/sources.list.d/ubuntu.sources."$(date +"%F")"
+        sudo sed -i 's/^Types: deb$/Types: deb deb-src/' /etc/apt/sources.list.d/ubuntu.sources
         sudo apt-get -y update
         sudo apt-get -y install nfs-kernel-server
         sudo systemctl enable --now nfs-server
-        sudo apt-get -y build-dep vagrant ruby-libvirt
+        sudo apt-get -y build-dep ruby-libvirt
         sudo apt-get -y install ebtables dnsmasq-base
         sudo apt-get -y install libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
         sudo vagrant plugin install vagrant-libvirt
@@ -197,7 +200,10 @@ jobs:
         EOF
 
     - name: Run vagrant up
-      run: sudo vagrant up --no-tty almalinux
+      run: |
+        # TODO to solve "undefined method `exists?'" error
+        sudo sed -i 's/exists?/exist?/g' /root/.vagrant.d/gems/3.3.6/gems/dotenv-0.11.1/lib/dotenv.rb
+        sudo vagrant up --no-tty almalinux
 
     - name: Get system release
       run: |
@@ -212,6 +218,10 @@ jobs:
             sudo vagrant ssh almalinux -c "sudo dnf install -y --enablerepo='extras-common' almalinux-kitten-release-devel"
             sudo vagrant ssh almalinux -c "sudo dnf install -y --enablerepo='${enable_repo,,} devel' python3-pip beakerlib"
             sudo vagrant ssh almalinux -c "sudo sh -c  'export PATH=$PATH:/usr/local/bin; pip install flexparser==0.3.1 tmt'"
+            ;;
+          9)
+            sudo vagrant ssh almalinux -c "sudo dnf -y install epel-release"
+            sudo vagrant ssh almalinux -c "sudo dnf install -y --enablerepo=${enable_repo,,} tmt initscripts-service"
             ;;
           *)
             sudo vagrant ssh almalinux -c "sudo dnf -y install epel-release"


### PR DESCRIPTION
Update github-hosted runner:
- install Vagrant packages provided by Hashicorp, Ubuntu 24.04 doesn't provide own
- use workaround for Ruby Gem dotenv version 0.11.1 to mitigate "undefined method `exists?'" error

Install initscripts-service into 9-th release