### PR TITLE
CI: Do not use ALBS repository to install beakerlib packages on AlmaLinux 10 and Kitten

### DIFF
--- a/.github/workflows/almalinux-compose-test-arm64.yml
+++ b/.github/workflows/almalinux-compose-test-arm64.yml
@@ -241,7 +241,6 @@ jobs:
             sudo sh -c 'export PATH=$PATH:/usr/local/bin; pip install flexparser==0.3.1 tmt'
             ;;
           10)
-            sudo dnf config-manager --add-repo https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-aarch64-20670-br/
             sudo dnf install -y ${dnf_opts} epel-release
             sudo dnf install -y ${dnf_opts} python3-pip beakerlib initscripts-service
             sudo sh -c  'export PATH=$PATH:/usr/local/bin; pip install flexparser==0.3.1 tmt'

--- a/.github/workflows/almalinux-compose-test-x86_64.yml
+++ b/.github/workflows/almalinux-compose-test-x86_64.yml
@@ -272,8 +272,6 @@ jobs:
             sudo vagrant ssh almalinux -c "sudo sh -c  'export PATH=$PATH:/usr/local/bin; pip install flexparser==0.3.1 tmt'"
             ;;
           10*)
-            [ "${{ matrix.variant }}" = "10" ] && basearch=x86_64 || basearch=x86_64_v2
-            sudo vagrant ssh almalinux -c "sudo dnf config-manager --add-repo https://build.almalinux.org/pulp/content/builds/AlmaLinux-Kitten-10-${basearch}-20670-br/"
             sudo vagrant ssh almalinux -c "sudo dnf install -y ${dnf_opts} epel-release"
             sudo vagrant ssh almalinux -c "sudo dnf install -y ${dnf_opts} python3-pip beakerlib initscripts-service"
             sudo vagrant ssh almalinux -c "sudo sh -c  'export PATH=$PATH:/usr/local/bin; pip install flexparser==0.3.1 tmt'"


### PR DESCRIPTION
The packages are available via AlmaLinux `devel` and EPEL repositories.