### PR TITLE
p_lftp: fetch timestamp from repo.almalinux.org instead of mirror.centos.org

### DIFF
--- a/tests/legacy/p_lftp/10_lftp_http_test.sh
+++ b/tests/legacy/p_lftp/10_lftp_http_test.sh
@@ -12,7 +12,7 @@ if [ "$CONTAINERTEST" -eq "1" ]; then
     exit 0
 fi
 
-URL="http://mirror.centos.org/"
+URL="https://repo.almalinux.org/almalinux/"
 
 CHECK_FOR="UTC"
 FILE="timestamp.txt"


### PR DESCRIPTION
## Summary
- The lftp HTTP probe in `tests/legacy/p_lftp/10_lftp_http_test.sh` fetches `timestamp.txt` from `mirror.centos.org`. When that host is unreachable from the test runner, lftp hangs with no timeout and the whole p_lftp test fails at tmt's 5-minute hard limit (observed in a recent compose run).
- This PR points the probe at `https://repo.almalinux.org/almalinux/timestamp.txt` instead. It is the natural source for an AlmaLinux compose test and removes the dependency on CentOS infrastructure.

## Test plan
- [x] Reproduced the test inside an `almalinux:9` container against the new URL: 50/50 passes, ~580ms median.
- [x] Same harness against `mirror.centos.org` from this network: 50/50 passes today (so the original failure was a transient outage of that host, not a deterministic bug — but the swap removes the external dependency).
- [ ] Run the full `legacy` plan in compose-tests CI / openQA against the next compose to confirm `p_lftp` is green.