### PR TITLE
squid: probe repo.almalinux.org instead of mirror.centos.org

### DIFF
--- a/tests/squid/test.sh
+++ b/tests/squid/test.sh
@@ -13,7 +13,7 @@ rlJournalStart
   rlPhaseEnd
 
   rlPhaseStartTest "Should find timestamp"
-  rlRun "squidclient -T 2 http://mirror.centos.org/ | grep -q timestamp"
+  rlRun "squidclient -T 2 http://repo.almalinux.org/almalinux/ | grep -q timestamp"
   rlPhaseEnd
 
   rlPhaseStartCleanup


### PR DESCRIPTION
## Summary
- The squid smoke test used `squidclient -T 2 http://mirror.centos.org/` to confirm the proxy could fetch a remote URL. Failure mode observed in a recent compose run: mirror.centos.org didn't respond inside 2 s and the test reported FAIL.
- `mirror.centos.org` is CentOS infrastructure and occasionally unreachable from the runner — unrelated to anything AlmaLinux actually ships.
- This PR switches the probe to `http://repo.almalinux.org/almalinux/` (project mirror; autoindex still contains the literal `timestamp` via `timestamp.txt`). The `-T 2` timeout is preserved so genuine slowness on the AlmaLinux mirror is still flagged loudly.

## Test plan
- [x] Verified inside an `almalinux:9` container: install squid, start it, run `squidclient -T 30 http://repo.almalinux.org/almalinux/ | grep -q timestamp` 50× — 50/50 pass, ~80 ms median, max 181 ms (well under the 2 s budget kept on the wire).
- [ ] Run the full `ng` plan in compose-tests CI / openQA against the next compose to confirm `/tests/squid` is green.