### PR TITLE
p_osbuild: skip on x86_64_v2 hosts

### DIFF
--- a/tests/legacy/p_osbuild/osbuild_test.sh
+++ b/tests/legacy/p_osbuild/osbuild_test.sh
@@ -19,6 +19,14 @@ if [ "$CONTAINERTEST" -eq "1" ]; then
     exit 0
 fi
 
+# osbuild-composer ships x86_64 (v3-baseline) repo definitions only; the build
+# chroot pulls v3 glibc which aborts on a v2 host with "CPU does not support
+# x86-64-v3". Detect the v2 variant via the installed glibc arch tag.
+if [ "$(rpm -q --qf '%{ARCH}' glibc)" = "x86_64_v2" ]; then
+    t_Log "osbuild-composer lacks x86_64_v2 repo definitions -> SKIP"
+    exit 0
+fi
+
 t_Log "Running $0 - osbuild: create '$test_toml'"
 cat > $test_toml <<EOF
 name = "$blueprint"


### PR DESCRIPTION
## Summary
- `p_osbuild` consistently fails on the `AlmaLinux 10-x86_64_v2` job (e.g. [run 25257620818](https://github.com/AlmaLinux/compose-tests/actions/runs/25257620818), and previously [25231168180](https://github.com/AlmaLinux/compose-tests/actions/runs/25231168180)) with `Fatal glibc error: CPU does not support x86-64-v3` during the `org.osbuild.rpm` stage.
- Root cause: osbuild-composer's bundled repo definitions for AlmaLinux 10 point only at the standard `x86_64` (v3-baseline) compose, so the build chroot pulls v3 glibc and the loader aborts on the v2 CPU before the first scriptlet finishes.
- Skip the test when the host is x86_64_v2, detected via `rpm -q --qf '%{ARCH}' glibc` (since `uname -m` reports plain `x86_64` on both variants).
- Installation of `osbuild-composer` in `0-install_osbuild.sh` still runs on v2, so we keep coverage of the package being installable.

## Test plan
- [ ] CI green on the `AlmaLinux 10-x86_64_v2` job — `p_osbuild` reports SKIP instead of FAIL.
- [ ] CI still green on `AlmaLinux 10` (v3) job — `p_osbuild` runs to completion as before.
- [ ] Spot-check the test log for the new `osbuild-composer lacks x86_64_v2 repo definitions -> SKIP` line on v2.