### PR TITLE
ci: bump GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/almalinux-compose-test-arm64.yml
+++ b/.github/workflows/almalinux-compose-test-arm64.yml
@@ -93,7 +93,7 @@ jobs:
     needs: start-runner # required to start the main job when the runner is ready
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Prepare stuff
       run: |
@@ -307,17 +307,17 @@ jobs:
         cd ${{ env.tmt_run_dir }}/
         tar cf ${{github.action_path}}/output.tar $( find . -name output.txt ) || true
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: Tests log
         path: ${{github.action_path}}/log.txt
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: Tests results
         path: ${{github.action_path}}/*.results.yaml
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: Tests output
         path: ${{github.action_path}}/output.tar
@@ -380,7 +380,7 @@ jobs:
 
     - name: Print tests summary
       if: job.steps.run-tests.status == failure() || failure()
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         result-encoding: string
         script: |

--- a/.github/workflows/almalinux-compose-test-x86_64.yml
+++ b/.github/workflows/almalinux-compose-test-x86_64.yml
@@ -44,7 +44,7 @@ jobs:
         variant: ${{ fromJSON(format('["{0}"]', ( inputs.version_major == '10-kitten' && '10-kitten", "10-kitten-x86_64_v2' || ( inputs.version_major == '10' && '10", "10-x86_64_v2' || inputs.version_major ) ) )) }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Prepare stuff
       run: |
@@ -342,17 +342,17 @@ jobs:
         sudo vagrant ssh almalinux -c 'sudo sh -c "cd ${{ env.tmt_run_dir }}/; tar cf output.tar plans/legacy/execute/data/guest/default-0/tests/legacy/*/output.txt plans/ng/execute/data/guest/default-0/tests/*/output.txt plans/ng/execute/data/guest/default-0/tests/*/*/output.txt plans/ng/execute/data/guest/default-0/tests/*/*/*/output.txt"'
         sudo vagrant scp almalinux:${{ env.tmt_run_dir }}/output.tar ${{github.action_path}}/output.tar
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: ${{ matrix.variant }} tests log
         path: ${{github.action_path}}/log.txt
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: ${{ matrix.variant }} tests results
         path: ${{github.action_path}}/*.results.yaml
 
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v6
       with:
         name: ${{ matrix.variant }} tests output
         path: ${{github.action_path}}/output.tar
@@ -412,7 +412,7 @@ jobs:
 
     - name: Print tests summary
       if: job.steps.run-tests.status == failure() || failure()
-      uses: actions/github-script@v7
+      uses: actions/github-script@v8
       with:
         result-encoding: string
         script: |


### PR DESCRIPTION
## Summary
- Bumps deprecated Node.js 20 actions to their Node.js 24 equivalents to silence the runner warning and stay ahead of the **June 2, 2026** force-upgrade and **September 16, 2026** Node.js 20 removal.
- `actions/checkout@v4` → `v5`
- `actions/upload-artifact@v4` → `v6` (v5 still defaults to `node20`, so it would not have fixed the warning)
- `actions/github-script@v7` → `v8`

## Notes
- No API/input/output changes between v4 and v6 of `upload-artifact`; the behavioral breaking changes (immutable artifacts, no re-uploads to the same name, 500/job cap, hidden-file exclusion) all happened back at v4 — already in use here.
- `upload-artifact@v6` requires Actions Runner ≥ 2.327.1. The x86_64 workflow runs on GitHub-hosted `ubuntu-24.04` (current). The arm64 workflow runs on a self-hosted EC2 runner registered fresh per job by `NextChapterSoftware/ec2-action-builder@v1.5`, which pulls a current runner — should be fine, but worth confirming on first run.

## Test plan
- [ ] Run `almalinux-compose-test-x86_64` workflow and confirm no Node.js deprecation warning appears
- [ ] Run `almalinux-compose-test-arm64` workflow and confirm the EC2 self-hosted runner is on Actions Runner ≥ 2.327.1 and uploads succeed
- [ ] Verify all three artifacts (tests log / tests results / tests output) still upload correctly in both workflows