### PR TITLE
Add 'testing repository' option to compose-test workflows

### DIFF
--- a/.github/workflows/almalinux-compose-test-arm64.yml
+++ b/.github/workflows/almalinux-compose-test-arm64.yml
@@ -24,6 +24,11 @@ on:
           type: boolean
           default: true
 
+        testing_repository:
+          description: 'Add testing repository'
+          type: boolean
+          default: false
+
         disable_default_repos:
           description: 'Disable system default repositories'
           type: boolean
@@ -224,6 +229,18 @@ jobs:
         gpgkey=file://${{ env.rpm_gpg_key }}
         EOF
 
+    - name: Create AlmaLinux testing pulp repository
+      # Kitten has no testing repository, so skip it there
+      if: inputs.pulp_repository && inputs.testing_repository && inputs.version_major != '10-kitten'
+      run: |
+        cat <<'EOF'>/etc/yum.repos.d/almalinux-testing-pulp.repo
+        [almalinux-${{ env.pulp_root }}-testing-pulp]
+        baseurl = https://build.almalinux.org/pulp/content/prod/almalinux-${{ env.pulp_root }}-testing-$arch/
+        enabled = 1
+        name = almalinux-${{ env.pulp_root }}-testing-pulp
+        gpgkey=file://${{ env.rpm_gpg_key }}
+        EOF
+
     - name: Create AlmaLinux nvidia pulp repository
       if: env.nvidia == 'true' && inputs.pulp_repository
       run: |
@@ -245,6 +262,13 @@ jobs:
     - name: Get system release
       run: |
         echo "system_release=$(cat /etc/almalinux-release)" >> $GITHUB_ENV
+
+    - name: Add testing repository
+      # With pulp the testing repo comes from pulp (see the pulp step above).
+      # Kitten has no testing repository, so skip it there.
+      if: inputs.testing_repository && !inputs.pulp_repository && inputs.version_major != '10-kitten'
+      run: |
+        sudo dnf install -y almalinux-release-testing
 
     - name: Prepare test infrastructure
       run: |

--- a/.github/workflows/almalinux-compose-test-x86_64.yml
+++ b/.github/workflows/almalinux-compose-test-x86_64.yml
@@ -24,6 +24,11 @@ on:
           type: boolean
           default: true
 
+        testing_repository:
+          description: 'Add testing repository'
+          type: boolean
+          default: false
+
         disable_default_repos:
           description: 'Disable system default repositories'
           type: boolean
@@ -245,6 +250,18 @@ jobs:
         gpgkey=file://${{ env.rpm_gpg_key }}
         EOF
 
+    - name: Create AlmaLinux testing pulp repository
+      # Kitten has no testing repository, so skip it there
+      if: inputs.pulp_repository && inputs.testing_repository && !startsWith(matrix.variant, '10-kitten')
+      run: |
+        cat <<'EOF'>./almalinux-testing-pulp.repo
+        [almalinux-${{ env.pulp_root }}-testing-pulp]
+        baseurl = https://build.almalinux.org/pulp/content/prod/almalinux-${{ env.pulp_root }}-testing-${{ env.basearch }}/
+        enabled = 1
+        name = almalinux-${{ env.pulp_root }}-testing-pulp
+        gpgkey=file://${{ env.rpm_gpg_key }}
+        EOF
+
     - name: Create AlmaLinux nvidia pulp repository
       if: env.nvidia == 'true' && inputs.pulp_repository
       run: |
@@ -280,6 +297,13 @@ jobs:
       run: |
         system_release=$(sudo vagrant ssh almalinux -c "cat /etc/almalinux-release")
         echo "system_release=${system_release}" >> $GITHUB_ENV
+
+    - name: Add testing repository
+      # With pulp the testing repo comes from pulp (see the pulp step above).
+      # Kitten has no testing repository, so skip it there.
+      if: inputs.testing_repository && !inputs.pulp_repository && !startsWith(matrix.variant, '10-kitten')
+      run: |
+        sudo vagrant ssh almalinux -c "sudo dnf install -y almalinux-release-testing"
 
     - name: Prepare test infrastructure
       run: |

--- a/ci/Vagrant/Vagrantfile
+++ b/ci/Vagrant/Vagrantfile
@@ -25,6 +25,11 @@ Vagrant.configure("2") do |config|
         sudo cp -av /vagrant/almalinux-pulp.repo /etc/yum.repos.d/almalinux-pulp.repo || \
         true
 
+        # Put in place almalinux-testing-pulp.repo if exists
+        test -e /vagrant/almalinux-testing-pulp.repo && \
+        sudo cp -av /vagrant/almalinux-testing-pulp.repo /etc/yum.repos.d/almalinux-testing-pulp.repo || \
+        true
+
         # Put in place almalinux-nvidia-pulp.repo if exists
         test -e /vagrant/almalinux-nvidia-pulp.repo && \
         sudo cp -av /vagrant/almalinux-nvidia-pulp.repo /etc/yum.repos.d/almalinux-nvidia-pulp.repo || \


### PR DESCRIPTION
## Summary

Adds a new **`testing_repository`** `workflow_dispatch` input (disabled by default) after the **`pulp_repository`** option in both the x86_64 and arm64 compose-test workflows. When enabled, it makes the AlmaLinux *testing* repository available during the run.

## Behavior

The repo is sourced based on whether pulp is enabled:

- **Pulp enabled** → a new *"Create AlmaLinux testing pulp repository"* step writes a `.repo` pointing at `https://build.almalinux.org/pulp/content/prod/almalinux-<pulp_root>-testing-<arch>/`.
  - x86_64: written on the host and copied into the VM via a new block in `ci/Vagrant/Vagrantfile`.
  - arm64: written directly to `/etc/yum.repos.d/`.
- **Pulp disabled** → `dnf install -y almalinux-release-testing`.

## Notes

- The option is **ignored for Kitten**, which has no testing repository (verified absent on pulp). Guarded via `!startsWith(matrix.variant, '10-kitten')` (x86_64) and `inputs.version_major != '10-kitten'` (arm64).
- The pulp testing path `almalinux-<root>-testing-<arch>` was verified to exist for 8/9/10 on the pulp server.
- In the pulp case the testing repo is enabled before `dnf update`, so testing packages can be pulled in during the system update — consistent with how the other pulp repos already behave.