### PR TITLE
plans: set sbin-inclusive PATH for test execution (fix tmt 1.75.0 regression)

### DIFF
--- a/plans/legacy.fmf
+++ b/plans/legacy.fmf
@@ -1,6 +1,12 @@
 summary: Imported t_functional tests
 
 environment:
+    # tmt >= 1.75.0 no longer leaks the runner's process environment into
+    # test commands (teemtee/tmt#4900), so /usr/sbin and /sbin are no longer
+    # on PATH by default. The legacy t_functional scripts call privileged
+    # tools (useradd, ip, service, auditctl, setsebool, tcpdump, ...) by bare
+    # name, so set an sbin-inclusive PATH explicitly.
+    PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
     YUMDEBUG: 0
     SKIP_QA_HARNESS: 1
     vendor: "almalinux"

--- a/plans/legacy.fmf
+++ b/plans/legacy.fmf
@@ -2,11 +2,12 @@ summary: Imported t_functional tests
 
 environment:
     # tmt >= 1.75.0 no longer leaks the runner's process environment into
-    # test commands (teemtee/tmt#4900), so /usr/sbin and /sbin are no longer
-    # on PATH by default. The legacy t_functional scripts call privileged
-    # tools (useradd, ip, service, auditctl, setsebool, tcpdump, ...) by bare
-    # name, so set an sbin-inclusive PATH explicitly.
+    # test commands (teemtee/tmt#4900). Restore the variables the suite
+    # relied on: an sbin-inclusive PATH (tests call useradd, ip, service,
+    # auditctl, setsebool, tcpdump, ... by bare name) and HOME (e.g. p_go's
+    # `go build` needs HOME/GOCACHE to locate its build cache).
     PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    HOME: "/root"
     YUMDEBUG: 0
     SKIP_QA_HARNESS: 1
     vendor: "almalinux"

--- a/plans/ng.fmf
+++ b/plans/ng.fmf
@@ -2,10 +2,11 @@ summary: New generation tests fully leveraging tmt
 
 environment:
     # tmt >= 1.75.0 no longer leaks the runner's process environment into
-    # test commands (teemtee/tmt#4900), so /usr/sbin and /sbin are no longer
-    # on PATH by default. Tests calling privileged tools (useradd, usermod,
-    # the bpf-* helpers, ...) by bare name need an sbin-inclusive PATH.
+    # test commands (teemtee/tmt#4900). Restore the variables the suite
+    # relied on: an sbin-inclusive PATH (tests call useradd, usermod, the
+    # bpf-* helpers, ... by bare name) and HOME.
     PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+    HOME: "/root"
 discover:
     how: fmf
     exclude: /legacy

--- a/plans/ng.fmf
+++ b/plans/ng.fmf
@@ -1,5 +1,11 @@
 summary: New generation tests fully leveraging tmt
 
+environment:
+    # tmt >= 1.75.0 no longer leaks the runner's process environment into
+    # test commands (teemtee/tmt#4900), so /usr/sbin and /sbin are no longer
+    # on PATH by default. Tests calling privileged tools (useradd, usermod,
+    # the bpf-* helpers, ...) by bare name need an sbin-inclusive PATH.
+    PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 discover:
     how: fmf
     exclude: /legacy


### PR DESCRIPTION
## Problem

The compose-tests suite started failing on the same commit that previously passed:

- **Pass:** [run 26945759392](https://github.com/AlmaLinux/compose-tests/actions/runs/26945759392) (Jun 4) — 133/133 tests passed
- **Fail:** [run 27097580353](https://github.com/AlmaLinux/compose-tests/actions/runs/27097580353) (Jun 7) — ~18 legacy/ng tests fail

Both runs are the **same commit** (`1b49e3e`) with the **same test scripts**, so the regression is environmental.

Every failing test fails with `command not found` (or a missing artifact downstream of one) on a binary that lives in `/usr/sbin` or `/sbin`:

| Test(s) | Missing command |
|---|---|
| `p_audit` | `auditctl` (auditd never starts) |
| `p_bridge-utils`, `p_network`, `p_tcpdump` | `ip`, `ifconfig`, `tcpdump` |
| `p_openssh`, `p_passwd`, `p_shadow-utils`, `p_dovecot` | `useradd`, `userdel`, `usermod`, `runuser` |
| `p_initscripts`, `p_tftp-server` | `service` |
| `p_nfs`, `p_vsftpd` | `exportfs`, `setsebool` |
| `p_cracklib` | `cracklib-check` |
| `p_logwatch`, `p_iptraf`, `p_mdadm` | `logwatch`, `iptraf-ng`, `mdadm` |
| `/tests/podman` | `useradd`, `usermod`, `userdel` |
| `/tests/libbpf-tools` | `bpf-*` helpers |

## Root cause

The workflow `pip install`s `tmt` unpinned. Between the two runs it moved **1.74.0 → 1.75.0**, which shipped [teemtee/tmt#4900](https://github.com/teemtee/tmt/pull/4900) — *"Do not populate the default command environment with tmt process envvars."* Commands run on the guest no longer inherit tmt's `os.environ`, so the runner's `PATH` (which included `/usr/sbin:/sbin`) is no longer forwarded. The legacy `t_functional` scripts and several ng tests call privileged tools by bare name and depend on sbin being on `PATH`.

## Fix

Set an explicit sbin-inclusive `PATH` in the `legacy` and `ng` plan environments, making the suite independent of tmt's env-forwarding behavior (robust across future tmt upgrades).

```yaml
PATH: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
```
