### PR TITLE
test(nvidia): use exact module names on x86_64

### DIFF
--- a/tests/legacy/p_kmod-nvidia-open/check_sb_and_installation.sh
+++ b/tests/legacy/p_kmod-nvidia-open/check_sb_and_installation.sh
@@ -21,7 +21,18 @@ if [[ $SKIP -eq 0 ]]; then
     t_InstallPackage kmod-nvidia-open
     t_InstallPackage nvidia-open-kmod
 
-    for i in $(rpm -ql kmod-nvidia-open | grep '\.ko$'); do
+    if [[ "$arch" == "x86_64" ]]; then
+        # Derive the module names from the package's .ko files (strip the
+        # path and the .ko extension). Using the bare names means modinfo
+        # resolves them against the running kernel's modules.dep, so we also
+        # verify they are visible from the running kernel, not just that the
+        # package ships signed .ko files.
+        MODULES=$(rpm -ql kmod-nvidia-open | grep '\.ko$' | sed 's#.*/##; s#\.ko$##')
+    else
+        MODULES=$(rpm -ql kmod-nvidia-open | grep '\.ko$')
+    fi
+
+    for i in $MODULES; do
         modinfo $i | grep $kmod_nvidia_sb_key
         t_CheckExitStatus $?
     done


### PR DESCRIPTION
## What

On x86_64, check the NVIDIA kernel modules by name instead of by file path. The names are derived from the package's `.ko` file list (strip the path and `.ko` extension):

```bash
MODULES=$(rpm -ql kmod-nvidia-open | grep '\.ko$' | sed 's#.*/##; s#\.ko$##')
```

This yields `nvidia-drm`, `nvidia-modeset`, `nvidia-uvm`, `nvidia` — no hardcoded list, the package stays the source of truth.

## Why

Running `modinfo` against the module *name* resolves it through the running kernel's `modules.dep`. This verifies both:
- the module is correctly signed with the expected SB key, and
- the module is actually **visible from the running kernel**, not merely shipped as a file in the package.

Other arches (aarch64) keep the original `rpm -ql` file-path behavior. The logic is unified into a single loop driven by a `MODULES` variable selected per arch.