### PR TITLE
test(nvidia): run on 9 and 10 for both x86_64 and aarch64

### DIFF
--- a/tests/legacy/p_kmod-nvidia-open/check_sb_and_installation.sh
+++ b/tests/legacy/p_kmod-nvidia-open/check_sb_and_installation.sh
@@ -7,11 +7,7 @@ arch=$(uname -m)
 
 SKIP=1
 
-if [[ "$centos_ver" -eq 9 && ("$arch" == "x86_64" || "$arch" == "aarch64") ]]; then
-  SKIP=0
-fi
-
-if [[ "$centos_ver" -eq 10 && "$arch" != "x86_64" ]]; then
+if [[ ("$centos_ver" -eq 9 || "$centos_ver" -eq 10) && ("$arch" == "x86_64" || "$arch" == "aarch64") ]]; then
   SKIP=0
 fi
 


### PR DESCRIPTION
## What

Run the kmod-nvidia-open signature/visibility test on **both** AlmaLinux 9 and 10, for **both** x86_64 and aarch64.

Collapses the two separate version/arch `SKIP` checks into a single condition:

```bash
if [[ ("$centos_ver" -eq 9 || "$centos_ver" -eq 10) && ("$arch" == "x86_64" || "$arch" == "aarch64") ]]; then
  SKIP=0
fi
```

## Why

The previous logic split the el9 and el10 cases inconsistently. Unify them so the test runs on all four version/arch combinations it supports.

> Note: the x86_64_v2 skip fix lives in #68 (arch derived from the glibc RPM), kept separate from this coverage change.