### PR TITLE
test(nvidia): derive arch from glibc rpm to skip x86_64_v2

### DIFF
--- a/tests/legacy/p_kmod-nvidia-open/check_sb_and_installation.sh
+++ b/tests/legacy/p_kmod-nvidia-open/check_sb_and_installation.sh
@@ -3,7 +3,11 @@
 
 t_Log "Running $0 -  Verifying that kmod-nvidia-open is correctly signed with correct cert"
 
-arch=$(uname -m)
+# Derive the arch from the glibc RPM rather than `uname -m`: on x86_64_v2
+# composes `uname -m` still reports plain "x86_64", but the NVIDIA driver is
+# not built for x86_64_v2, so the package arch (x86_64_v2) is what we must
+# match on to skip those runners.
+arch=$(rpm -q --queryformat '%{ARCH}' glibc)
 
 SKIP=1
 


### PR DESCRIPTION
## What

Derive the arch from the glibc RPM instead of `uname -m`:

```bash
arch=$(rpm -q --queryformat '%{ARCH}' glibc)
```

## Why

`uname -m` reports plain `x86_64` on **x86_64_v2** composes, so the `== "x86_64"` skip check would run the test there. The NVIDIA open driver is not built for x86_64_v2 — `almalinux-release-nvidia-driver` is absent — so the test fails immediately at install ([run 27206726711](https://github.com/AlmaLinux/compose-tests/actions/runs/27206726711)).

Reading the arch from the glibc package returns `x86_64_v2` on those runners, so the existing `x86_64` match naturally excludes them while still running on x86_64 and aarch64.
