### PR TITLE
ci(x86_64): set 120gb volume for RunsOn runners

### DIFF
--- a/.github/workflows/almalinux-compose-test-x86_64.yml
+++ b/.github/workflows/almalinux-compose-test-x86_64.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: >-
       ${{
         github.repository_owner == 'AlmaLinux' &&
-          format('runs-on={0}/family=c8i.8xlarge/image=ubuntu24-full-x64/nested-virt', github.run_id)
+          format('runs-on={0}/family=c8i.8xlarge/image=ubuntu24-full-x64/nested-virt/volume=120gb', github.run_id)
         ||
         'ubuntu-24.04'
       }}


### PR DESCRIPTION
## Problem

Since the migration to RunsOn runners, all `workflow_dispatch` runs for AlmaLinux **8** and **9** die with:

> The self-hosted runner lost communication with the server.

consistently at ~43 minutes into the job, in the middle of the `Run tests` step (example: [run 27348800823](https://github.com/AlmaLinux/compose-tests/actions/runs/27348800823)). AlmaLinux 10 / 10-kitten jobs pass fine on the same instances. All three recent Vagrantfile guest-sizing variants (25% / 75% / 25% RAM) died identically, so it is not guest RAM/CPU — and host metrics on passing AL10 runs show max 23% RAM and load 2.5 of 32 cores. Instances are on-demand, so spot reclaims are ruled out too.

## Root cause

The default RunsOn root volume is **40gb** (`disk=default` ≈ `volume=40gb`), much of it already consumed by the `ubuntu24-full-x64` image. The vagrant guest's qcow2 overlay lives on that same root filesystem and grows monotonically with every package install/removal performed by the test suites. The 8/9 suites write substantially more than 10 (firefox, java, xorg, real `p_kvdo` VDO volumes — a no-op on 10 — and a heavier `p_osbuild`).

When the volume fills up, qemu's default `werror=enospc` policy pauses the guest, `Run tests` hangs forever, the runner agent on the full disk stops heartbeating, and GitHub declares the runner lost ~10 minutes later — hence the suspiciously constant ~43m job age across all failures. AlmaLinux 10 simply finishes before hitting the limit. GitHub-hosted runners (used before the RunsOn migration) have a larger usable disk, which is why the same suites passed there as recently as June 3-4.

## Fix

Request a 120gb volume via the RunsOn `volume=` label. 80gb would likely suffice, but 120gb leaves headroom for osbuild/kvdo-heavy runs.

## Also included

Reverted the today's "ci(Vagrant): rebalance host-based guest sizing" (cb82a6a), restoring the 75%-of-host-RAM guest sizing from a280efe. That rebalance was an attempt to cure these very failures by shrinking the guest, but the 25%-RAM variant died identically — RAM was never the problem. With the disk fixed, the larger guest (48gb on c8i.8xlarge) is a better fit for the kvdo/osbuild-heavy suites.
