### PR TITLE
ci: add orchestrator to run x86_64 and arm64 compose tests in one run

### DIFF
--- a/.github/workflows/almalinux-compose-test-arm64.yml
+++ b/.github/workflows/almalinux-compose-test-arm64.yml
@@ -44,6 +44,39 @@ on:
           type: boolean
           default: true
 
+  # Allow this workflow to be called from the 'almalinux-compose-test' orchestrator.
+  # 'workflow_call' has no 'choice' input type, so 'version_major' is a string here.
+  workflow_call:
+    inputs:
+      version_major:
+        description: 'AlmaLinux major version'
+        required: true
+        type: string
+      pungi_repository:
+        description: 'Add pungi repositories'
+        type: boolean
+        default: false
+      pulp_repository:
+        description: 'Add pulp repositories'
+        type: boolean
+        default: true
+      testing_repository:
+        description: 'Add testing repository'
+        type: boolean
+        default: false
+      disable_default_repos:
+        description: 'Disable system default repositories'
+        type: boolean
+        default: false
+      rerun_failed:
+        description: 'Re-run failed tests'
+        type: boolean
+        default: true
+      notify_mattermost:
+        description: 'Send results notification to Mattermost'
+        type: boolean
+        default: true
+
 jobs:
 
   compose-test:

--- a/.github/workflows/almalinux-compose-test-x86_64.yml
+++ b/.github/workflows/almalinux-compose-test-x86_64.yml
@@ -39,6 +39,35 @@ on:
           type: boolean
           default: true
 
+  # Allow this workflow to be called from the 'almalinux-compose-test' orchestrator.
+  # 'workflow_call' has no 'choice' input type, so 'version_major' is a string here.
+  workflow_call:
+    inputs:
+      version_major:
+        description: 'AlmaLinux major version'
+        required: true
+        type: string
+      pungi_repository:
+        description: 'Add pungi repositories'
+        type: boolean
+        default: false
+      pulp_repository:
+        description: 'Add pulp repositories'
+        type: boolean
+        default: true
+      testing_repository:
+        description: 'Add testing repository'
+        type: boolean
+        default: false
+      disable_default_repos:
+        description: 'Disable system default repositories'
+        type: boolean
+        default: false
+      rerun_failed:
+        description: 'Re-run failed tests'
+        type: boolean
+        default: true
+
 jobs:
   compose-test:
     name: AlmaLinux ${{ matrix.variant }}

--- a/.github/workflows/almalinux-compose-test.yml
+++ b/.github/workflows/almalinux-compose-test.yml
@@ -1,0 +1,86 @@
+name: almalinux-compose-test
+
+# Orchestrator: a single dispatch runs the compose tests on x86_64 (incl.
+# x86_64_v2) and aarch64 as parallel child jobs via reusable workflows.
+# The per-arch workflows can still be run on their own from the Actions UI.
+
+on:
+  workflow_dispatch:
+    inputs:
+
+      version_major:
+        description: 'AlmaLinux major version'
+        required: true
+        default: '10'
+        type: choice
+        options:
+          - 10-kitten
+          - 10
+          - 9
+          - 8
+
+      run_x86_64:
+        description: 'Run x86_64 (incl. x86_64_v2)'
+        type: boolean
+        default: true
+
+      run_arm64:
+        description: 'Run aarch64'
+        type: boolean
+        default: true
+
+      pungi_repository:
+        description: 'Add pungi repositories'
+        type: boolean
+
+      pulp_repository:
+        description: 'Add pulp repositories'
+        type: boolean
+        default: true
+
+      testing_repository:
+        description: 'Add testing repository'
+        type: boolean
+        default: false
+
+      disable_default_repos:
+        description: 'Disable system default repositories'
+        type: boolean
+        default: false
+
+      rerun_failed:
+        description: 'Re-run failed tests'
+        type: boolean
+        default: true
+
+      notify_mattermost:
+        description: 'Send results notification to Mattermost (aarch64)'
+        type: boolean
+        default: true
+
+jobs:
+
+  x86_64:
+    if: ${{ inputs.run_x86_64 }}
+    uses: ./.github/workflows/almalinux-compose-test-x86_64.yml
+    with:
+      version_major: ${{ inputs.version_major }}
+      pungi_repository: ${{ inputs.pungi_repository }}
+      pulp_repository: ${{ inputs.pulp_repository }}
+      testing_repository: ${{ inputs.testing_repository }}
+      disable_default_repos: ${{ inputs.disable_default_repos }}
+      rerun_failed: ${{ inputs.rerun_failed }}
+    secrets: inherit
+
+  arm64:
+    if: ${{ inputs.run_arm64 }}
+    uses: ./.github/workflows/almalinux-compose-test-arm64.yml
+    with:
+      version_major: ${{ inputs.version_major }}
+      pungi_repository: ${{ inputs.pungi_repository }}
+      pulp_repository: ${{ inputs.pulp_repository }}
+      testing_repository: ${{ inputs.testing_repository }}
+      disable_default_repos: ${{ inputs.disable_default_repos }}
+      rerun_failed: ${{ inputs.rerun_failed }}
+      notify_mattermost: ${{ inputs.notify_mattermost }}
+    secrets: inherit


### PR DESCRIPTION
Add 'almalinux-compose-test.yml' that dispatches both per-arch compose-test workflows as parallel child jobs via reusable workflows, so a single run exercises x86_64 (incl. x86_64_v2) and aarch64. Logs, summaries and artifacts of both arches surface under the one orchestrator run.

- Add a 'workflow_call' trigger to the x86_64 and arm64 workflows (job bodies unchanged; 'version_major' is a string there as workflow_call has no 'choice' input type).
- run_x86_64 / run_arm64 inputs allow running both arches or just one.
- secrets: inherit passes AWS/Mattermost secrets down to the arm64 job.

Each per-arch workflow can still be dispatched on its own from the Actions UI.